### PR TITLE
synchronize with upstream v0.3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
+          - {name: '3.12', python: '3.12', os: ubuntu-20.04, tox: py312}
           - {name: '3.11', python: '3.11', os: ubuntu-20.04, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-20.04, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-20.04, tox: py39}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 exclude: ^(tests/data/)
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
     -   id: black
         args: [-S, --line-length=79, --safe, --quiet]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -20,22 +20,22 @@ repos:
     rev: 6.1.0
     hooks:
     -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-autopep8
+-   repo: https://github.com/hhatto/autopep8
     rev: v2.0.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.10.0
+    rev: v3.12.0
     hooks:
     -   id: reorder-python-imports
         args: [--py37-plus]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.0.1
+    rev: v3.1.0
     hooks:
     -   id: add-trailing-comma
 # -   repo: https://github.com/asottile/setup-cfg-fmt

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,8 @@ Add the following config, if you have tessdata error like: "Error opening data f
 
 * **run_and_get_output** Returns the raw output from Tesseract OCR. Gives a bit more control over the parameters that are sent to tesseract.
 
+* **run_and_get_multiple_output** Returns like `run_and_get_output` but can handle multiple extensions. This function replaces the `extension: str` kwarg with `extension: List[str]` kwarg where a list of extensions can be specified and the corresponding data is returned after only one `tesseract` call. This function reduces the number of calls to `tesseract` when multiple output formats, like both text and bounding boxes,  are needed.
+
 **Parameters**
 
 ``image_to_data(image, lang=None, config='', nice=0, output_type=Output.STRING, timeout=0, pandas_config=None)``
@@ -245,12 +247,4 @@ As of Python-tesseract 0.3.1 the license is Apache License Version 2.0
 CONTRIBUTORS
 ------------
 - Originally written by `Samuel Hoffstaetter <https://github.com/h>`_
-- `Juarez Bochi <https://github.com/jbochi>`_
-- `Matthias Lee <https://github.com/madmaze>`_
-- `Lars Kistner <https://github.com/Sr4l>`_
-- `Ryan Mitchell <https://github.com/REMitchell>`_
-- `Emilio Cecchini <https://github.com/ceccoemi>`_
-- `John Hagen <https://github.com/johnthagen>`_
-- `Darius Morawiec <https://github.com/nok>`_
-- `Eddie Bedada <https://github.com/adbedada>`_
-- `Uğurcan Akyüz <https://github.com/ugurcanakyuz>`_
+- `Full list of contributors <https://github.com/madmaze/pytesseract/graphs/contributors>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/unstructured_pytesseract/__init__.py
+++ b/unstructured_pytesseract/__init__.py
@@ -16,4 +16,4 @@ from .pytesseract import TesseractNotFoundError
 from .pytesseract import TSVNotSupported
 
 
-__version__ = '0.3.12'
+__version__ = '0.3.13'

--- a/unstructured_pytesseract/pytesseract.py
+++ b/unstructured_pytesseract/pytesseract.py
@@ -18,7 +18,6 @@ from os import remove
 from os.path import normcase
 from os.path import normpath
 from os.path import realpath
-from pkgutil import find_loader
 from tempfile import NamedTemporaryFile
 from time import sleep
 from typing import List
@@ -32,13 +31,19 @@ from PIL import Image
 
 tesseract_cmd = 'tesseract'
 
-numpy_installed = find_loader('numpy') is not None
-if numpy_installed:
+try:
     from numpy import ndarray
 
-pandas_installed = find_loader('pandas') is not None
-if pandas_installed:
+    numpy_installed = True
+except ModuleNotFoundError:
+    numpy_installed = False
+
+try:
     import pandas as pd
+
+    pandas_installed = True
+except ModuleNotFoundError:
+    pandas_installed = False
 
 LOGGER = logging.getLogger('pytesseract')
 


### PR DESCRIPTION
This aims to synchronize `unstructured.pytesseract` fork with the latest version of upstream `pytesseract` (v0.3.13)